### PR TITLE
include exported target configuration in config.cmake.in file

### DIFF
--- a/config.cmake.in
+++ b/config.cmake.in
@@ -6,3 +6,5 @@ find_path(SIOCLIENT_INCLUDE_DIR sioclient/sio_client.h sioclient/sio_message.h s
 )
 set(SIOCLIENT_LIBRARIES ${SIOCLIENT_LIBRARY})
 set(SIOCLIENT_INCLUDE_DIRS ${SIOCLIENT_INCLUDE_DIR})
+
+include(${CMAKE_CURRENT_LIST_DIR}/sioclientTargets.cmake)


### PR DESCRIPTION
Hello,

I would like to propose a change to be able to use the exported target instead of the old INCLUDE and LIBRARY_DIR, the targets were already exported but not included in the config file.

Best Regards,
Csaba